### PR TITLE
Backport prerelease to trunk for jetpack-mu-wpcom 3.4.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.4.0-alpha] - unreleased
-
-This is an alpha version! The changes listed here are not final.
-
+## [3.4.0] - 2023-06-27
 ### Added
-- Check that the function jetpack_is_atomic_site exists before using it.
+- Check that the function jetpack_is_atomic_site exists before using it. [#31602]
 
 ## [3.3.0] - 2023-06-26
 ### Added
@@ -211,7 +208,7 @@ This is an alpha version! The changes listed here are not final.
 
 - Testing initial package release.
 
-[3.4.0-alpha]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v3.3.0...v3.4.0-alpha
+[3.4.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v3.0.0...v3.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.4.0-alpha",
+	"version": "3.4.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/src/class-jetpack-mu-wpcom.php
+++ b/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.4.0-alpha';
+	const PACKAGE_VERSION = '3.4.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**


### PR DESCRIPTION
Backporting prerelease branch to trunk for the jetpack-mu-wpcom 3.4.0 update.