### PR TITLE
Hide some launchpad items on trial plan

### DIFF
--- a/src/features/launchpad/launchpad-task-definitions.php
+++ b/src/features/launchpad/launchpad-task-definitions.php
@@ -1231,7 +1231,24 @@ function wpcom_launchpad_is_mobile_app_installed( $task, $is_complete ) {
  *
  * @return bool True if the site is a WOA site and WooCommerce is active.
  */
-function wpcom_launchpad_is_woocommerce_setup_visible() {
+function wpcom_launchpad_is_woocommerce_setup_visible( $task ) {
+	// Get current plan
+	$is_ecommerce_trial_plan = false;
+	if( function_exists( 'wpcom_get_site_purchases' ) ) {
+		$purchases = wpcom_get_site_purchases();
+		foreach ( $purchases as $purchase ) {
+			if ( 'ecommerce-trial-bundle-monthly' === $purchase->product_slug ) {
+				$is_ecommerce_trial_plan = true;
+				break;
+			}
+		}
+	}
+
+	// Hide these tasks in ecommerce trial plan
+	if( in_array( $task['id'], [ 'woo_marketing', 'woo_launch_site' ] ) && $is_ecommerce_trial_plan ) {
+		return false;
+	}
+
 	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
 	if ( ! $is_atomic_site ) {
 		return false;


### PR DESCRIPTION
This PR hides the "Grow your business" and "Launch your site" options in the launchpad when the site plan is e-commerce trial.

## Testing

In order to test this patch, follow the WoA instructions here: PCYsg-Osp-p2

You should test with a site that has a WooExpress trial plan and another with an Entrepreneur plan to see how the two menu items appear in the latter but not in the former.